### PR TITLE
Support avatarId key in IssueType, throw Exception if response is not a JSON

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -28,6 +28,7 @@ use chobie\Jira\Api\Authentication\AuthenticationInterface;
 use chobie\Jira\Api\Client\ClientInterface;
 use chobie\Jira\Api\Result;
 use chobie\Jira\Api\Client\CurlClient;
+use chobie\Jira\Api\Exception;
 
 class Api
 {
@@ -469,6 +470,10 @@ class Api
 
         if (strlen($result)) {
             $json = json_decode($result, true);
+            if (!is_array($json)) {
+                 throw new Exception("JIRA Rest server returns unexpected result: " . $result);
+            }
+
             if ($this->options & self::AUTOMAP_FIELDS) {
                 if (isset($json['issues'])) {
                     if (!count($this->fields)) {

--- a/src/Jira/IssueType.php
+++ b/src/Jira/IssueType.php
@@ -45,6 +45,7 @@ class IssueType
         "iconUrl",
         "name",
         "subtask",
+        "avatarId",
     );
 
     public function __construct($types)


### PR DESCRIPTION
Recent changes in Atlassian broke jira-api-restclient.
1. avatarId is now returned in issueTypes (jira-api-restclient threw Exception upon unrecognised key.)
2. Accidentally using http://*.atlassian.net instead of https:// will redirect and use GET instead of POST.
3. Using GET when POST is required would have returned an HTTP error, but CurlClient returned it as a string. Thus, Api.php failed to parse.
