### PR TITLE
Added `Api::addWorklog` and `Api::deleteWorklog` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added optional override for the filename in `Api::createAttachment` by [@betterphp]
 - Allow getting issue count back from `Walker` class by [@aik099].
 - Setup `.gitattributes` for better `CHANGELOG.md` merging by [@glensc].
+- Added `Api::addWorklog` and `Api::deleteWorklog` calls for more control over the work logs [@dumconstantin] and [@aik099].
 
 ### Changed
 - Classes/interfaces were renamed to use namespaces by [@chobie].
@@ -71,3 +72,4 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [@aik099]: https://github.com/aik099
 [@betterphp]: https://github.com/betterphp
 [@glensc]: https://github.com/glensc
+[@dumconstantin]: https://github.com/dumconstantin

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -37,6 +37,8 @@ class Api
 	const REQUEST_PUT = 'PUT';
 	const REQUEST_DELETE = 'DELETE';
 
+    const WORKLOG_COMMENT = 'transition:';
+
 	const AUTOMAP_FIELDS = 0x01;
 
 	/**
@@ -852,6 +854,25 @@ class Api
 
 		return $result;
 	}
+
+    /**
+     * create JIRA Worklog
+     *
+     * @param $issue
+     * @param $filename
+     * @param array $options
+     * @return mixed
+     */
+    public function createWorklogFromTransition($issue, $transitionId, $time, $startDate)
+    {
+        $options = array(
+            "timeSpent" => $time,
+            "started" => "2013-09-01T10:30:18.932+0530",
+            "comment" => self::WORKLOG_COMMENT . $transitionId
+        );
+
+        return $this->api(self::REQUEST_POST, "/rest/api/2/issue/" . $issue . "/worklog", $options);
+    }
 
 	/**
 	 * Returns project components.

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -376,23 +376,26 @@ class Api
 	/**
 	 * Creates worklog for na issue.
 	 *
-	 * @param string $issue_key Issue key should be "YOURPROJ-22".
-	 * @param string $time      Time.
-	 * @param array  $options   Options.
+	 * @param string         $issue_key  Issue key should be "YOURPROJ-22".
+	 * @param integer        $started    Start time (unix timestamp).
+	 * @param string|integer $time_spent Either string in "2w 4d 6h 45m" format or second count as a number.
+	 * @param array          $params     Params.
 	 *
 	 * @return Result|false
 	 * @since  2.0.0
 	 */
-	public function createWorklog($issue_key, $time, array $options = array())
+	public function createWorklog($issue_key, $started, $time_spent, array $params = array())
 	{
-		$options = array_merge(
-			array(
-				'timeSpent' => $time,
-			),
-			$options
-		);
+		$params['started'] = date('Y-m-dTG:m:s.vO', $started);
 
-		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $options);
+		if ( is_int($time_spent) ) {
+			$params['timeSpentSeconds'] = $time_spent;
+		}
+		else {
+			$params['timeSpent'] = $time_spent;
+		}
+
+		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $params);
 	}
 
 	/**

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -867,7 +867,7 @@ class Api
     {
         $options = array(
             "timeSpent" => $time,
-            "started" => "2013-09-01T10:30:18.932+0530",
+            "started" => $startDate,
             "comment" => self::WORKLOG_COMMENT . $transitionId
         );
 

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -375,26 +375,26 @@ class Api
 		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/comment', $issue_key), $params);
 	}
 
-    /**
-     * create JIRA Worklog
-     *
-     * @param $issue
-     * @param $filename
-     * @param array $options
-     * @return mixed
-     */
-    public function createWorklog($issueKey, $time, $options = array())
-    {
+	/**
+	 * Creates worklog for na issue.
+	 *
+	 * @param string $issue_key Issue key should be "YOURPROJ-22".
+	 * @param string $time      Time.
+	 * @param array  $options   Options.
+	 *
+	 * @return mixed
+	 */
+	public function createWorklog($issue_key, $time, array $options = array())
+	{
+		$options = array_merge(
+			array(
+				'timeSpent' => $time,
+			),
+			$options
+		);
 
-        $options = array_merge(
-            array(
-                "timeSpent" => $time,
-            ),
-            $options
-        );
-
-        return $this->api(self::REQUEST_POST, sprintf("/rest/api/2/issue/%s/worklog", $issueKey), $options);
-    }
+		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $options);
+	}
 
 	/**
 	 * Get all worklogs for an issue.
@@ -410,20 +410,26 @@ class Api
 		return $this->api(self::REQUEST_GET, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $params);
 	}
 
-    /**
-     * remove a JIRA Worklog
-     *
-     * @param $issueKey
-     * @return mixed
-     */
-    public function removeWorklog($issueKey, $worklogId)
-    {
-        $options = array(
-            "adjustEstimate" => "auto"
-        );
+	/**
+	 * Remove an issue worklog.
+	 *
+	 * @param string  $issue_key  Issue key should be "YOURPROJ-22".
+	 * @param integer $worklog_id Work Log ID.
+	 *
+	 * @return mixed
+	 */
+	public function removeWorklog($issue_key, $worklog_id)
+	{
+		$options = array(
+			'adjustEstimate' => 'auto',
+		);
 
-        return $this->api(self::REQUEST_DELETE, sprintf("/rest/api/2/issue/%s/worklog/%s", $issueKey, $worklogId), $options);
-    }
+		return $this->api(
+			self::REQUEST_DELETE,
+			sprintf('/rest/api/2/issue/%s/worklog/%s', $issue_key, $worklog_id),
+			$options
+		);
+	}
 
 	/**
 	 * Get available transitions for a ticket.

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -37,7 +37,7 @@ class Api
 	const REQUEST_PUT = 'PUT';
 	const REQUEST_DELETE = 'DELETE';
 
-    const WORKLOG_COMMENT = 'transition:';
+    const TRANSITION_DELIMITER = 'transition:';
 
 	const AUTOMAP_FIELDS = 0x01;
 
@@ -868,7 +868,7 @@ class Api
         $options = array(
             "timeSpent" => $time,
             "started" => $startDate,
-            "comment" => self::WORKLOG_COMMENT . $transitionId
+            "comment" => self::TRANSITION_DELIMITER . $transitionId
         );
 
         return $this->api(self::REQUEST_POST, "/rest/api/2/issue/" . $issue . "/worklog", $options);

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -38,6 +38,7 @@ class Api
 	const REQUEST_DELETE = 'DELETE';
 
 	const AUTOMAP_FIELDS = 0x01;
+	const DATE_TIME_FORMAT = 'Y-m-d\TG:m:s.vO';
 
 	/**
 	 * Endpoint URL.
@@ -377,17 +378,14 @@ class Api
 	 * Adds a worklog for an issue.
 	 *
 	 * @param string         $issue_key  Issue key should be "YOURPROJ-22".
-	 * @param integer        $started    Start time (unix timestamp).
 	 * @param string|integer $time_spent Either string in "2w 4d 6h 45m" format or second count as a number.
 	 * @param array          $params     Params.
 	 *
-	 * @return Result|false
+	 * @return array
 	 * @since  2.0.0
 	 */
-	public function addWorklog($issue_key, $started, $time_spent, array $params = array())
+	public function addWorklog($issue_key, $time_spent, array $params = array())
 	{
-		$params['started'] = date('Y-m-dTG:m:s.vO', $started);
-
 		if ( is_int($time_spent) ) {
 			$params['timeSpentSeconds'] = $time_spent;
 		}
@@ -395,7 +393,12 @@ class Api
 			$params['timeSpent'] = $time_spent;
 		}
 
-		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $params);
+		return $this->api(
+			self::REQUEST_POST,
+			sprintf('/rest/api/2/issue/%s/worklog', $issue_key),
+			$params,
+			true
+		);
 	}
 
 	/**
@@ -419,7 +422,7 @@ class Api
 	 * @param integer $worklog_id Work Log ID.
 	 * @param array   $params     Params.
 	 *
-	 * @return Result|false
+	 * @return array
 	 * @since  2.0.0
 	 */
 	public function deleteWorklog($issue_key, $worklog_id, array $params = array())
@@ -427,7 +430,8 @@ class Api
 		return $this->api(
 			self::REQUEST_DELETE,
 			sprintf('/rest/api/2/issue/%s/worklog/%s', $issue_key, $worklog_id),
-			$params
+			$params,
+			true
 		);
 	}
 

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -374,7 +374,7 @@ class Api
 	}
 
 	/**
-	 * Creates worklog for na issue.
+	 * Adds a worklog for an issue.
 	 *
 	 * @param string         $issue_key  Issue key should be "YOURPROJ-22".
 	 * @param integer        $started    Start time (unix timestamp).
@@ -384,7 +384,7 @@ class Api
 	 * @return Result|false
 	 * @since  2.0.0
 	 */
-	public function createWorklog($issue_key, $started, $time_spent, array $params = array())
+	public function addWorklog($issue_key, $started, $time_spent, array $params = array())
 	{
 		$params['started'] = date('Y-m-dTG:m:s.vO', $started);
 
@@ -413,7 +413,7 @@ class Api
 	}
 
 	/**
-	 * Remove an issue worklog.
+	 * Deletes an issue worklog.
 	 *
 	 * @param string  $issue_key  Issue key should be "YOURPROJ-22".
 	 * @param integer $worklog_id Work Log ID.
@@ -422,7 +422,7 @@ class Api
 	 * @return Result|false
 	 * @since  2.0.0
 	 */
-	public function removeWorklog($issue_key, $worklog_id, array $params = array())
+	public function deleteWorklog($issue_key, $worklog_id, array $params = array())
 	{
 		return $this->api(
 			self::REQUEST_DELETE,

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -375,6 +375,27 @@ class Api
 		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/comment', $issue_key), $params);
 	}
 
+    /**
+     * create JIRA Worklog
+     *
+     * @param $issue
+     * @param $filename
+     * @param array $options
+     * @return mixed
+     */
+    public function createWorklog($issueKey, $time, $options = array())
+    {
+
+        $options = array_merge(
+            array(
+                "timeSpent" => $time,
+            ),
+            $options
+        );
+
+        return $this->api(self::REQUEST_POST, sprintf("/rest/api/2/issue/%s/worklog", $issueKey), $options);
+    }
+
 	/**
 	 * Get all worklogs for an issue.
 	 *
@@ -388,6 +409,21 @@ class Api
 	{
 		return $this->api(self::REQUEST_GET, sprintf('/rest/api/2/issue/%s/worklog', $issue_key), $params);
 	}
+
+    /**
+     * remove a JIRA Worklog
+     *
+     * @param $issueKey
+     * @return mixed
+     */
+    public function removeWorklog($issueKey, $worklogId)
+    {
+        $options = array(
+            "adjustEstimate" => "auto"
+        );
+
+        return $this->api(self::REQUEST_DELETE, sprintf("/rest/api/2/issue/%s/worklog/%s", $issueKey, $worklogId), $options);
+    }
 
 	/**
 	 * Get available transitions for a ticket.
@@ -854,27 +890,6 @@ class Api
 
 		return $result;
 	}
-
-    /**
-     * create JIRA Worklog
-     *
-     * @param $issue
-     * @param $filename
-     * @param array $options
-     * @return mixed
-     */
-    public function createWorklog($issueKey, $time, $options = array())
-    {
-
-        $options = array_merge(
-            array(
-                "timeSpent" => $time,
-            ),
-            $options
-        );
-
-        return $this->api(self::REQUEST_POST, "/rest/api/2/issue/" . $issueKey . "/worklog", $options);
-    }
 
 	/**
 	 * Returns project components.

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -37,7 +37,6 @@ class Api
 	const REQUEST_PUT = 'PUT';
 	const REQUEST_DELETE = 'DELETE';
 
-    const TRANSITION_DELIMITER = 'transition:';
 
 	const AUTOMAP_FIELDS = 0x01;
 

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -863,15 +863,17 @@ class Api
      * @param array $options
      * @return mixed
      */
-    public function createWorklogFromTransition($issue, $transitionId, $time, $startDate)
+    public function createWorklog($issueKey, $time, $options = array())
     {
-        $options = array(
-            "timeSpent" => $time,
-            "started" => $startDate,
-            "comment" => self::TRANSITION_DELIMITER . $transitionId
+
+        $options = array_merge(
+            array(
+                "timeSpent" => $time,
+            ),
+            $options
         );
 
-        return $this->api(self::REQUEST_POST, "/rest/api/2/issue/" . $issue . "/worklog", $options);
+        return $this->api(self::REQUEST_POST, "/rest/api/2/issue/" . $issueKey . "/worklog", $options);
     }
 
 	/**

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -37,7 +37,6 @@ class Api
 	const REQUEST_PUT = 'PUT';
 	const REQUEST_DELETE = 'DELETE';
 
-
 	const AUTOMAP_FIELDS = 0x01;
 
 	/**
@@ -381,7 +380,8 @@ class Api
 	 * @param string $time      Time.
 	 * @param array  $options   Options.
 	 *
-	 * @return mixed
+	 * @return Result|false
+	 * @since  2.0.0
 	 */
 	public function createWorklog($issue_key, $time, array $options = array())
 	{
@@ -415,7 +415,8 @@ class Api
 	 * @param string  $issue_key  Issue key should be "YOURPROJ-22".
 	 * @param integer $worklog_id Work Log ID.
 	 *
-	 * @return mixed
+	 * @return Result|false
+	 * @since  2.0.0
 	 */
 	public function removeWorklog($issue_key, $worklog_id)
 	{

--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -414,20 +414,17 @@ class Api
 	 *
 	 * @param string  $issue_key  Issue key should be "YOURPROJ-22".
 	 * @param integer $worklog_id Work Log ID.
+	 * @param array   $params     Params.
 	 *
 	 * @return Result|false
 	 * @since  2.0.0
 	 */
-	public function removeWorklog($issue_key, $worklog_id)
+	public function removeWorklog($issue_key, $worklog_id, array $params = array())
 	{
-		$options = array(
-			'adjustEstimate' => 'auto',
-		);
-
 		return $this->api(
 			self::REQUEST_DELETE,
 			sprintf('/rest/api/2/issue/%s/worklog/%s', $issue_key, $worklog_id),
-			$options
+			$params
 		);
 	}
 

--- a/tests/Jira/ApiTest.php
+++ b/tests/Jira/ApiTest.php
@@ -313,6 +313,86 @@ class ApiTest extends TestCase
 	}
 
 	/**
+	 * @param string|integer $time_spent           Time spent.
+	 * @param array          $expected_rest_params Expected rest params.
+	 *
+	 * @return void
+	 * @dataProvider addWorkLogWithoutCustomParamsDataProvider
+	 */
+	public function testAddWorkLogWithoutCustomParams($time_spent, array $expected_rest_params)
+	{
+		$response = '{}';
+
+		$this->expectClientCall(
+			Api::REQUEST_POST,
+			'/rest/api/2/issue/JRA-15/worklog',
+			$expected_rest_params,
+			$response
+		);
+
+		$actual = $this->api->addWorklog('JRA-15', $time_spent);
+
+		$this->assertEquals(json_decode($response, true), $actual, 'The response is json-decoded.');
+	}
+
+	public static function addWorkLogWithoutCustomParamsDataProvider()
+	{
+		return array(
+			'integer time spent' => array(12, array('timeSpentSeconds' => 12)),
+			'string time spent' => array('12m', array('timeSpent' => '12m')),
+		);
+	}
+
+	public function testAddWorklogWithCustomParams()
+	{
+		$response = '{}';
+
+		$started = date(Api::DATE_TIME_FORMAT, 1621026000);
+		$this->expectClientCall(
+			Api::REQUEST_POST,
+			'/rest/api/2/issue/JRA-15/worklog',
+			array('timeSpent' => '12m', 'started' => $started),
+			$response
+		);
+
+		$actual = $this->api->addWorklog('JRA-15', '12m', array('started' => $started));
+
+		$this->assertEquals(json_decode($response, true), $actual, 'The response is json-decoded.');
+	}
+
+	public function testDeleteWorkLogWithoutCustomParams()
+	{
+		$response = '{}';
+
+		$this->expectClientCall(
+			Api::REQUEST_DELETE,
+			'/rest/api/2/issue/JRA-15/worklog/11256',
+			array(),
+			$response
+		);
+
+		$actual = $this->api->deleteWorklog('JRA-15', 11256);
+
+		$this->assertEquals(json_decode($response, true), $actual, 'The response is json-decoded.');
+	}
+
+	public function testDeleteWorkLogWithCustomParams()
+	{
+		$response = '{}';
+
+		$this->expectClientCall(
+			Api::REQUEST_DELETE,
+			'/rest/api/2/issue/JRA-15/worklog/11256',
+			array('custom' => 'param'),
+			$response
+		);
+
+		$actual = $this->api->deleteWorklog('JRA-15', 11256, array('custom' => 'param'));
+
+		$this->assertEquals(json_decode($response, true), $actual, 'The response is json-decoded.');
+	}
+
+	/**
 	 * Expects a particular client call.
 	 *
 	 * @param string       $method       Request method.


### PR DESCRIPTION
This is a rebased version of the https://github.com/console-helpers/jira-api-restclient/pull/36 with minor improvements.

The new PR was created because the original PR by @dumconstantin was made from the `master` branch of his fork and therefore couldn't be modified by this repository maintainers.

Closes #36.

---

Both added API calls on JIRA side accept `Query parameters`, but support for them would be implemented separately in the #220.