### PR TITLE
Adjust "Api::createRemoteLink" params with Jira API params

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -723,27 +723,25 @@ class Api
 	 * @param string $global_id    Global ID.
 	 * @param array  $application  Application.
 	 *
-	 * @return array|false
+	 * @return array
 	 * @since  2.0.0
+	 * @link   https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-remote-links/#api-rest-api-2-issue-issueidorkey-remotelink-post
 	 */
 	public function createRemoteLink(
 		$issue_key,
-		array $object = array(),
+		array $object,
 		$relationship = null,
 		$global_id = null,
 		array $application = null
 	) {
-		$options = array(
+		$params = array_filter(array(
 			'globalId' => $global_id,
 			'relationship' => $relationship,
 			'object' => $object,
-		);
+			'application' => $application,
+		));
 
-		if ( $application !== null ) {
-			$options['application'] = $application;
-		}
-
-		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/remotelink', $issue_key), $options, true);
+		return $this->api(self::REQUEST_POST, sprintf('/rest/api/2/issue/%s/remotelink', $issue_key), $params, true);
 	}
 
 	/**

--- a/tests/Jira/ApiTest.php
+++ b/tests/Jira/ApiTest.php
@@ -152,6 +152,109 @@ class ApiTest extends AbstractTestCase
 		$this->assertFalse($this->api->releaseVersion(111000, $release_date, array('test' => 'extra')));
 	}
 
+	/**
+	 * @dataProvider createRemoteLinkDataProvider
+	 */
+	public function testCreateRemoteLink(array $method_params, array $expected_api_params)
+	{
+		$response = file_get_contents(__DIR__ . '/resources/api_create_remote_link.json');
+
+		$this->expectClientCall(
+			Api::REQUEST_POST,
+			'/rest/api/2/issue/JRE-123/remotelink',
+			$expected_api_params,
+			$response
+		);
+
+		$expected = json_decode($response, true);
+		$actual = call_user_func_array(array($this->api, 'createRemoteLink'), $method_params);
+
+		if ( $actual !== false ) {
+			$this->assertEquals($expected, $actual);
+		}
+	}
+
+	public static function createRemoteLinkDataProvider()
+	{
+		return array(
+			'object only' => array(
+				array(
+					'JRE-123',
+					array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+				),
+				array(
+					'object' => array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+				),
+			),
+			'object+relationship' => array(
+				array(
+					'JRE-123',
+					array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+					'blocked by',
+				),
+				array(
+					'relationship' => 'blocked by',
+					'object' => array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+				),
+			),
+			'object+global_id' => array(
+				array(
+					'JRE-123',
+					array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+					null,
+					'global-id',
+				),
+				array(
+					'globalId' => 'global-id',
+					'object' => array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+				),
+			),
+			'object+application' => array(
+				array(
+					'JRE-123',
+					array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+					null,
+					null,
+					array(
+						'name' => 'My Acme Tracker',
+						'type' => 'com.acme.tracker',
+					),
+				),
+				array(
+					'object' => array(
+						'title' => 'TSTSUP-111',
+						'url' => 'http://www.mycompany.com/support?id=1',
+					),
+					'application' => array(
+						'name' => 'My Acme Tracker',
+						'type' => 'com.acme.tracker',
+					),
+				),
+			),
+		);
+	}
+
 	public function testFindVersionByName()
 	{
 		$project_key = 'POR';

--- a/tests/Jira/resources/api_create_remote_link.json
+++ b/tests/Jira/resources/api_create_remote_link.json
@@ -1,0 +1,4 @@
+{
+	"id": 17095,
+	"self": "https://test.atlassian.net/rest/api/2/issue/JRE-123/remotelink/17095"
+}


### PR DESCRIPTION
The following problems with the `Api::createRemoteLink` method are addressed:

* don't specify the `globalId` and `relationship` parameters with NULL values to the Jira REST API call, because it's not a guaranteed behavior of Atlassian to ignore NULL values
* made an `$object` method argument mandatory to be in line with an API specs
* added test

Closes #120